### PR TITLE
Added test skip mechanism and disabled several flaky tests with it

### DIFF
--- a/all_docs/1001-maintenance-mode-test.py
+++ b/all_docs/1001-maintenance-mode-test.py
@@ -17,6 +17,7 @@ def setup_module():
     db.bulk_docs(docs)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_all_docs():
     # Check that we can run with maintenance mode on a number
     # of servers. This has an assumption that the last node in

--- a/bulk_docs/1000-check-dupes-test.py
+++ b/bulk_docs/1000-check-dupes-test.py
@@ -13,16 +13,17 @@ NUM_CLUSTER_TEST_CASES = 25
 NUM_LOCAL_TEST_CASES = 100
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_clustered_bulk_doc_dupes():
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_clustered_bulk_doc_dupes")
     db.reset()
     run_ordering_check(db, NUM_CLUSTER_TEST_CASES)
 
 
 def test_backdoor_bulk_doc_dupes():
     srv = cloudant.random_node()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_backdoor_bulk_doc_dupes")
     db.reset()
     run_ordering_check(db, NUM_LOCAL_TEST_CASES)
 

--- a/changes/1001-maintenance-mode-test.py
+++ b/changes/1001-maintenance-mode-test.py
@@ -27,7 +27,7 @@ SINCE_SEQ_2 = "".join("""
 
 def setup_module():
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_maint_mode_test")
     db.reset(q=4)
     docs = []
     for i in range(NUM_ROWS):
@@ -73,7 +73,7 @@ def run_changes(num_results, **kwargs):
     # map so that we can remove non-shard-containing nodes from
     # service first.
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_maint_mode_test")
     nodes = cloudant.nodes(interface="public")
     try:
         for n in nodes[:-1]:

--- a/changes/1002-node-replacement-test.py
+++ b/changes/1002-node-replacement-test.py
@@ -19,7 +19,7 @@ SINCE_SEQ = "".join("""\
 
 def setup_module():
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_node_repl_test")
     db.reset(q=4)
     docs = []
     for i in range(NUM_ROWS):
@@ -33,7 +33,7 @@ def test_basic_node_replacement():
     # First run the changes on node1 so we get the
     # last update seq.
     node1 = cloudant.get_server(node="node1@127.0.0.1", interface="public")
-    db = node1.db("test_suite_db")
+    db = node1.db("test_suite_db_node_repl_test")
     c = db.changes(since=SINCE_SEQ)
     assert_that(c.results, has_length(NUM_ROWS))
     last_seq = c.last_seq
@@ -44,7 +44,7 @@ def test_basic_node_replacement():
     try:
         node1.config_set("cloudant", "maintenance_mode", "true")
         node3 = cloudant.get_server(node="node3@127.0.0.1", interface="public")
-        db = node3.db("test_suite_db")
+        db = node3.db("test_suite_db_node_repl_test")
         c = db.changes(since=last_seq)
         assert_that(c.results, has_length(0))
     finally:

--- a/cloudant.py
+++ b/cloudant.py
@@ -13,7 +13,8 @@ import urllib
 import urlparse
 import StringIO
 import gzip as gziplib
-
+import functools
+import nose
 
 import requests
 from hamcrest.core.base_matcher import BaseMatcher
@@ -708,6 +709,26 @@ def nodes(interface="private", user="admin"):
     for name in CONFIG.nodes.keys():
         ret.append(get_server(node=name, interface=interface, user=user))
     return ret
+
+
+# Custom decorator for skipping tests run by Nose
+
+@nose.tools.nottest
+def skip_test(func=None, reason='BROKEN TEST'):
+    """
+    Decorator for skipping tests with a user-definable reason.
+    Example usage:
+        @skip_test(reason="SOME REASON")
+        def test_function_to_be_skipped()
+    """
+    if func is None:
+        return functools.partial(skip_test, reason=reason)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwds):
+        raise nose.SkipTest(reason)
+        return func(*args, **kwds)
+    return wrapper
 
 
 # Hamcrest helpers

--- a/cloudant.py
+++ b/cloudant.py
@@ -350,7 +350,7 @@ class Server(object):
             time.sleep(min_delay)
         while any(_match(t) for t in self.active_tasks()):
             if time.time() - start > max_delay:
-                raise RuntimError("Timeout waiting for indexer tasks")
+                raise RuntimeError("Timeout waiting for indexer tasks")
             time.sleep(1.0)
 
     def last_status_code(self):

--- a/cors/1001-cors-user-test.py
+++ b/cors/1001-cors-user-test.py
@@ -55,6 +55,7 @@ def setup_module():
         db.reset()
         db.set_security(SECURITY_DOC)
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_cors():
     srv = cloudant.get_server(auth=(USER, USER))
     origin = "http://example.com"
@@ -112,6 +113,7 @@ def test_cors():
             has_key("rows")
         )
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_minimal_cors():
     srv = cloudant.get_server(auth=(USER, USER))
     origin = "http://baz.com"
@@ -171,6 +173,7 @@ def test_minimal_cors():
             has_key("rows")
         )
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_no_cors():
     srv = cloudant.get_server(auth=(USER, USER))
     origin = "http://random-no-cors-domain.com"

--- a/dbcopy/1000-key-removal-test.py
+++ b/dbcopy/1000-key-removal-test.py
@@ -12,16 +12,17 @@ DDOC = {
         "bam": {
             "map": "function(doc) {emit(null, 1);}",
             "reduce": "_sum",
-            "dbcopy": "test_suite_db_copy"
+            "dbcopy": "test_suite_db_key_removal_test_dbcopy"
         }
     }
 }
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_removal():
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
-    dbcopy = srv.db("test_suite_db_copy")
+    db = srv.db("test_suite_db_key_removal_test")
+    dbcopy = srv.db("test_suite_db_key_removal_test_dbcopy")
 
     db.reset()
     dbcopy.reset()

--- a/dbcopy/1001-dbcopy-salt-test.py
+++ b/dbcopy/1001-dbcopy-salt-test.py
@@ -10,16 +10,17 @@ DDOC = {
         "bar": {
             "map": "function(doc) {emit(doc._id, 1);}",
             "reduce": "_sum",
-            "dbcopy": "test_suite_db_copy"
+            "dbcopy": "test_suite_salt_test_dbcopy"
         }
     }
 }
 
 
+@cloudant.skip_test(reason="BROKEN TEST - FB 31024")
 def test_doc_salt():
     srv = cloudant.get_server()
-    db = srv.db("test_suite_db")
-    dbcopy = srv.db("test_suite_db_copy")
+    db = srv.db("test_suite_db_salt_test")
+    dbcopy = srv.db("test_suite_salt_test_dbcopy")
 
     db.reset()
     dbcopy.reset()

--- a/docs/1000-concurrent-client-writes.py
+++ b/docs/1000-concurrent-client-writes.py
@@ -12,6 +12,7 @@ TEST_TIME = 5
 NUM_CLIENTS = 20
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_multiple_clients():
     # Here we're testing multiple clients attempting to update
     # a single document and racing to get their update in. To
@@ -29,7 +30,7 @@ def test_multiple_clients():
     # Although we can check for the absence of errors which will
     # have to do for now.
     srv = cloudant.random_node()
-    db = srv.db("test_suite_db")
+    db = srv.db("test_suite_db_concurrent_client_writes")
     db.reset()
 
     docid = "test_doc"

--- a/global_changes/0001-basic-api.py
+++ b/global_changes/0001-basic-api.py
@@ -26,6 +26,7 @@ def test_no_options():
     assert_that(c, has_property("last_seq"))
 
 
+@cloudant.skip_test(reason="BROKEN TEST - FB 31024")
 def test_db_event_types():
     # I'm mashing each of these tests together because cycling
     # through dbs is a good way to get the dbcore nodes to hit
@@ -69,6 +70,7 @@ def test_db_event_types():
             has_item(has_entries({"dbname": dbname, "type": "deleted"})))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")  # https://gist.github.com/robfraz/3283ce59177bc561e57c
 def test_limit():
     srv = cloudant.get_server()
     db = srv.db("global_changes")
@@ -80,6 +82,7 @@ def test_limit():
         assert_that(c1.results, is_not(has_item(row)))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")  # https://gist.github.com/robfraz/3283ce59177bc561e57c
 def test_parameters_are_ignored():
     srv = cloudant.get_server()
     c = srv.global_changes(limit=1, foo="bar")
@@ -113,6 +116,7 @@ def test_400_on_bad_paramters():
             assert_that(r.status_code, is_(400))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")  # https://gist.github.com/robfraz/3283ce59177bc561e57c
 def test_descending():
     srv = cloudant.get_server()
     db = srv.db("global_changes")
@@ -135,6 +139,7 @@ def test_long_poll():
     assert_that(c.results, only_contains(has_key("seq")))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")  # https://gist.github.com/robfraz/3283ce59177bc561e57c
 def test_long_poll_limit():
     srv = cloudant.get_server()
     c = srv.global_changes(feed="longpoll", limit=3)
@@ -143,6 +148,7 @@ def test_long_poll_limit():
     assert_that(c.results, only_contains(has_key("seq")))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_long_poll_timeout():
     srv = cloudant.get_server()
     seq = srv.global_changes().last_seq
@@ -192,6 +198,7 @@ def test_continuous():
     assert_that(c.results, only_contains(has_key("seq")))
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_continuous_limit():
     srv = cloudant.get_server()
     c = srv.global_changes(feed="continuous", limit=4, timeout=500)

--- a/global_changes/0002-authorization.py
+++ b/global_changes/0002-authorization.py
@@ -55,6 +55,7 @@ def test_unauthorized_sees_nothing():
             assert_that(True, is_(False))
 
 
+@cloudant.skip_test(reason="BROKEN TEST - FB 31024")
 def test_bad_role_sees_nothing():
     srv = cloudant.get_server()
     for user in UNAUTHED:

--- a/global_changes/0003-disable-global-changes.py
+++ b/global_changes/0003-disable-global-changes.py
@@ -11,6 +11,7 @@ def setup():
         db.create()
 
 
+@cloudant.skip_test(reason="BROKEN TEST - FB 31024")
 def test_disable_global_changes():
     srv = cloudant.get_server()
     db = srv.db("test_suite_db_global_changes")

--- a/gzip_content_encoding/1002-gzip-body-other-types.py
+++ b/gzip_content_encoding/1002-gzip-body-other-types.py
@@ -6,6 +6,7 @@ from hamcrest import *
 
 import cloudant
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_gzipped_body_jpeg_content_type():
     srv = cloudant.get_server()
     db = srv.db("test_suite_db")

--- a/internal_replication/1000-basic-internal-rep-test.py
+++ b/internal_replication/1000-basic-internal-rep-test.py
@@ -24,6 +24,7 @@ def mk_docid(src_val, tgt_val):
     return "_local/shard-sync-{0}-{1}".format(n1, n2)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_basic_internal_replication():
     srv = cloudant.get_server()
     db = srv.db("test_suite_db")

--- a/views/1001-design-cache-coherence-test.py
+++ b/views/1001-design-cache-coherence-test.py
@@ -36,18 +36,21 @@ def setup_module():
     DB.bulk_docs(docs)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_ddoc_one():
     design = save_design(ddoc_one)
     check_one()
     delete_design(design)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_ddoc_two():
     design = save_design(ddoc_two)
     check_two()
     delete_design(design)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_successive_updates():
     design = save_design(ddoc_one)
     design = save_design(ddoc_two, design)
@@ -58,6 +61,7 @@ def test_successive_updates():
     delete_design(design)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_coherent_validation_funs():
     DB.doc_save({"_id": "s", "key": "x", "val": 0, "reject_me": True})
     design = save_design(ddoc_one)

--- a/views/1001-maintenance-mode-test.py
+++ b/views/1001-maintenance-mode-test.py
@@ -30,10 +30,12 @@ def setup_module():
     db.bulk_docs(docs)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_map_views():
     run_view(False)
 
 
+@cloudant.skip_test(reason="FLAKY TEST - FB 31024")
 def test_reduce_view():
     run_view(True);
 


### PR DESCRIPTION
Initial work on making Quimby more stable, by simply skipping the most unstable tests for now - of which there are a lot.

There is much more work to be done in making Quimby stable that will be addressed in a later PR, mainly around adding in a proper test setup/teardown methodology and then using it to remove the large amount of test-state that is shared not only between individual tests but entire test runs...

BugzID: 31024
