### PR TITLE
Add maintenance mode search test to quimby

### DIFF
--- a/cloudant.py
+++ b/cloudant.py
@@ -483,6 +483,11 @@ class Database(object):
         path = self.path("_design", ddoc, "_view", vname)
         return self._exec_view(path, **kwargs)
 
+    def search(self, ddoc, sname, query, **kwargs):
+        path = self.path("_design", ddoc, "_search", sname)
+        args = "&".join("%s=%s" % (k,v) for k,v in kwargs.items())
+        return self.srv.res.get(path, params='q='+query+'&'+args).json()
+
     def changes(self, **kwargs):
         is_continuous = kwargs.get("feed") == "continuous"
         params = self._params(kwargs)

--- a/search/1000-maintenance-mode-test.py
+++ b/search/1000-maintenance-mode-test.py
@@ -1,0 +1,64 @@
+
+import time
+
+from hamcrest import *
+
+import cloudant
+
+
+NUM_ROWS = 100
+
+DDOC = {
+    "_id": "_design/searchtest",
+    "indexes": {
+        "searchtest": {
+            "index": "function(doc) {if(doc.value){index(\"value\", doc.value);}}"
+        }
+    }
+}
+
+
+def setup_module():
+    srv = cloudant.get_server()
+    db = srv.db("test_suite_db")
+    db.reset(q=1)
+    db.doc_save(DDOC)
+    docs = []
+    for i in range(NUM_ROWS):
+        docs.append({"value":i})
+    db.bulk_docs(docs)
+
+
+def test_search():
+    run_search()
+
+def run_search():
+    """\
+    Check that we can run with maintenance mode on a number
+    of servers. This has an assumption that the last node in
+    the cluster has a fully shard ring. To make this more better
+    we should compare the list of nodes returned to the shard
+    map so that we can remove non-shard-containing nodes from
+    service first.
+    """
+    srv = cloudant.get_server()
+    db = srv.db("test_suite_db")
+    nodes = cloudant.nodes(interface="private")
+    try:
+        for n in nodes[:-1]:
+            n.config_set("cloudant", "maintenance_mode", "true")
+            s = db.search("searchtest", "searchtest", query="*:*", stale="ok")
+            assert_that(s["total_rows"], greater_than_or_equal_to(0))
+        n = nodes[-1]
+        n.config_set("cloudant", "maintenance_mode", "true")
+        try:
+            db.search("searchtest", "searchtest", query="*:*", stale="ok")
+        except:
+            assert_that(srv.res.last_req.json(), has_key("error"))
+            assert_that(srv.res.last_req.json(),
+                has_entry("reason", "No DB shards could be opened."))
+        else:
+            raise AssertionError("Search Results should not be returned")
+    finally:
+        for n in nodes:
+            n.config_set("cloudant", "maintenance_mode", "false")


### PR DESCRIPTION
Will need to change maintenance mode config name from "cloudant"
to "couchdb" for dbnext.

BugzId:61702
